### PR TITLE
Fix GitHub Pages app: wire up component and fix runtime errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="styles.css">
     <title>QLD Tiny House Planner</title>
     <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
@@ -11,8 +10,6 @@
 </head>
 <body>
     <div id="root"></div>
-    <script type="text/babel">
-        // Component code for qld-tiny-house-planner can be included here
-    </script>
+    <script type="text/babel" src="qld-tiny-house-planner.jsx"></script>
 </body>
 </html>

--- a/qld-tiny-house-planner.jsx
+++ b/qld-tiny-house-planner.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+const { useState, useEffect, useRef, useCallback } = React;
 
 const QLD_COUNCILS = {
   "Brisbane City": { maxGFA: 80, minLot: 450, zone: "LDR", proximityRule: 20 },
@@ -244,7 +244,7 @@ select.input-field option { background: #1a2a1a; color: #e8ede8; }
 }
 `;
 
-export default function TinyHousePlanner() {
+function TinyHousePlanner() {
   const [step, setStep] = useState(0);
   const [resultTab, setResultTab] = useState("overview");
   const [formData, setFormData] = useState({ council: "", suburb: "", landSize: "", bedrooms: 1, constructionSize: "", material: "", finishLevel: "mid", siteCondition: "flat", hasOverlays: "no", budget: "", purpose: "family" });
@@ -1034,3 +1034,5 @@ export default function TinyHousePlanner() {
     </div>
   );
 }
+
+ReactDOM.createRoot(document.getElementById("root")).render(<TinyHousePlanner />);


### PR DESCRIPTION
- index.html had an empty script block and referenced a nonexistent styles.css; now loads qld-tiny-house-planner.jsx via Babel script tag
- Changed ES module import to destructuring from React global (required for UMD/Babel-in-browser)
- Removed `export default` (not valid in non-module scripts)
- Added ReactDOM.createRoot render call so the component actually mounts

https://claude.ai/code/session_01QezGrW8PUEedwhhX9NMdNm